### PR TITLE
Update kde_settings for wayland.

### DIFF
--- a/kde_settings.conf
+++ b/kde_settings.conf
@@ -6,6 +6,8 @@ User=
 [General]
 HaltCommand=/usr/bin/systemctl poweroff
 RebootCommand=/usr/bin/systemctl reboot
+DisplayServer=wayland
+GreeterEnvironment=QT_WAYLAND_SHELL_INTEGRATION=layer-shell
 
 [Theme]
 Current=breeze
@@ -13,3 +15,8 @@ Current=breeze
 [Users]
 MaximumUid=60513
 MinimumUid=1000
+
+[Wayland]
+Enable=true
+SessionDir=/usr/share/wayland-sessions
+CompositorCommand=/usr/bin/kwin_wayland --no-lockscreen

--- a/kde_settings.conf
+++ b/kde_settings.conf
@@ -8,6 +8,7 @@ HaltCommand=/usr/bin/systemctl poweroff
 RebootCommand=/usr/bin/systemctl reboot
 DisplayServer=wayland
 GreeterEnvironment=QT_WAYLAND_SHELL_INTEGRATION=layer-shell
+#GreeterEnvironment=QT_WAYLAND_SHELL_INTEGRATION=xdg-shell
 
 [Theme]
 Current=breeze


### PR DESCRIPTION
Wayland is going do be the default in kde6+, sddm should also run on wayland.